### PR TITLE
Fix UTF-8 encode in title and author

### DIFF
--- a/feed2red.pl
+++ b/feed2red.pl
@@ -30,6 +30,7 @@ use HTML::Entities;
 use Fcntl;
 use SDBM_File;
 use Digest::SHA qw(sha1_base64);
+use Encode;
 
 # read configuration
 readConfig();
@@ -147,7 +148,7 @@ foreach my $norm (keys %feeds)
 			$status = '';
 			if ($eTitle and $$f{ShowTitle} =~ /^y/i)
 				{
-				$status .= "\n[h3][url=" . $entry->link . "]${eTitle}[/url][/h3]\n";
+				$status .= "\n[h3][url=" . $entry->link . "]" . Encode::decode("utf8", $eTitle) . "[/url][/h3]\n";
 				}
 			if ($$f{UseQuote} =~ /^y/i)
 				{
@@ -163,7 +164,7 @@ foreach my $norm (keys %feeds)
 				}
 			if ($$f{UseShare} =~ /^y/i)
 				{
-				$status = "[share author='" . uri_escape_utf8($title) . "' profile='$feedLink' link='" . $entry->link . "' posted='$modUTC']$status\[/share]";
+				$status = "[share author='" . Encode::decode("utf8", $title) . "' profile='$feedLink' link='" . $entry->link . "' posted='$modUTC']$status\[/share]";
 				}
 			if ($$f{ExpireDays} =~ /^\d+$/)
 				{


### PR DESCRIPTION
This pull request fix the UTF-8 encode in title and author. It is working correctly in [Periódico channel](https://red.vilarejo.pro.br/channel/periodico). I did not test in non UTF-8 feeds.

Issue #2.
